### PR TITLE
Made connection optional in more places.

### DIFF
--- a/marklogic/models/certificate/authority.py
+++ b/marklogic/models/certificate/authority.py
@@ -37,7 +37,7 @@ class Authority(Model):
     a certificate authority. Certificate authorities are created by
     uploading trusted certificates.
     """
-    def __init__(self, certid):
+    def __init__(self, certid, connection=None, save_connection=True):
         """
         Create a new certificate authority. Except it doesn't, really.
         It just creates a reference to the certificate authority with the
@@ -46,6 +46,11 @@ class Authority(Model):
         """
         self._config = {'id': certid}
         self.id = certid
+        self.save_connection = save_connection
+        if save_connection:
+            self.connection = connection
+        else:
+            self.connection = None
 
     def certificate_id(self):
         """
@@ -137,7 +142,7 @@ class Authority(Model):
 
         return result
 
-    def read(self, connection):
+    def read(self, connection=None):
         """
         Loads the Authority from the MarkLogic server. This will refresh
         the properties of the object.
@@ -146,6 +151,9 @@ class Authority(Model):
 
         :return: The Authority object
         """
+        if connection is None:
+            connection = self.connection
+
         auth = Authority.lookup(self.id)
         if auth is None:
             return None
@@ -154,7 +162,7 @@ class Authority(Model):
             self.id = auth._config['certificate-id']
             return self
 
-    def delete(self, connection):
+    def delete(self, connection=None):
         """
         Deletes the Authority from the MarkLogic server.
 
@@ -166,6 +174,9 @@ class Authority(Model):
 
         :return: None
         """
+        if connection is None:
+            connection = self.connection
+
         uri = connection.uri("certificate-authorities", self.id,
                              properties=None)
 

--- a/marklogic/models/certificate/template.py
+++ b/marklogic/models/certificate/template.py
@@ -39,7 +39,8 @@ class Template(Model):
     a certificate template.
     """
     def __init__(self, name, description, cert_request,
-                 key_type="rsa", key_length=None, pass_phrase=None):
+                 key_type="rsa", key_length=None, pass_phrase=None,
+                 connection=None, save_connection=None):
         """
         Create a new certificate template.
         """
@@ -61,6 +62,11 @@ class Template(Model):
             self._config['options'] = options
 
         self.etag = None
+        self.save_connection = save_connection
+        if save_connection:
+            self.connection = connection
+        else:
+            self.connection = None
 
     def template_id(self):
         """
@@ -270,13 +276,16 @@ class Template(Model):
 
         return result
 
-    def create(self, connection):
+    def create(self, connection=None):
         """
         Creates the certificate template on the MarkLogic server.
 
         :param connection: The connection to a MarkLogic server
         :return: The Template object
         """
+        if connection == None:
+            connection = self.connection
+
         uri = connection.uri("certificate-templates")
         struct = self.marshal()
         response = connection.post(uri, payload=struct)
@@ -297,7 +306,7 @@ class Template(Model):
 
         return self
 
-    def read(self, connection):
+    def read(self, connection=None):
         """
         Loads the Template from the MarkLogic server. This will refresh
         the properties of the object.
@@ -306,6 +315,9 @@ class Template(Model):
 
         :return: The Template object
         """
+        if connection == None:
+            connection = self.connection
+
         if self.template_id() is None:
             validate_custom("Cannot read an unsaved template")
 
@@ -317,13 +329,16 @@ class Template(Model):
             self._config = auth._config
             return self
 
-    def update(self, connection):
+    def update(self, connection=None):
         """
         Updates the certificate template on the MarkLogic server.
 
         :param connection: The connection to a MarkLogic server
         :return: The Template object
         """
+        if connection == None:
+            connection = self.connection
+
         uri = connection.uri("certificate-templates", self.template_id())
 
         struct = self.marshal()
@@ -333,7 +348,7 @@ class Template(Model):
         response = connection.put(uri, payload=struct)
         return self
 
-    def delete(self, connection):
+    def delete(self, connection=None):
         """
         Deletes the Template from the MarkLogic server.
 
@@ -341,6 +356,9 @@ class Template(Model):
 
         :return: None
         """
+        if connection == None:
+            connection = self.connection
+
         uri = connection.uri("certificate-templates", self.template_id(),
                              properties=None)
 
@@ -349,7 +367,7 @@ class Template(Model):
 
     # ============================================================
 
-    def generate_template_certificate_authority(self, connection, valid_for):
+    def generate_template_certificate_authority(self, valid_for, connection=None):
         """
         Attempts to generate an template certificate authority.
 
@@ -357,6 +375,9 @@ class Template(Model):
 
         :return: The Template object.
         """
+        if connection == None:
+            connection = self.connection
+
         struct = {
             'operation': 'generate-template-certificate-authority',
             'valid-for': assert_type(valid_for, int)
@@ -372,8 +393,9 @@ class Template(Model):
 
         return self
 
-    def generate_temporary_certificate(self, connection, valid_for,
+    def generate_temporary_certificate(self, valid_for,
                                        common_name, dns_name, ip_addr,
+                                       connection=None,
                                        if_necessary=True):
         """
         Attempts to generate a temporary certificate.
@@ -390,6 +412,9 @@ class Template(Model):
 
         :return: The Template object.
         """
+        if connection == None:
+            connection = self.connection
+
         struct = {
             'operation': 'generate-temporary-certificate',
             'valid-for': assert_type(valid_for, int),
@@ -408,8 +433,8 @@ class Template(Model):
 
         return self
 
-    def get_certificate(self, connection,
-                        common_name, dns_name=None, ip_addr=None):
+    def get_certificate(self, common_name, dns_name=None, ip_addr=None,
+                        connection=None):
         """
         Attempts to get the relevant certificate.
 
@@ -419,6 +444,9 @@ class Template(Model):
 
         :return: The certificate or None if it isn't found.
         """
+        if connection == None:
+            connection = self.connection
+
         struct = {
             'operation': 'get-certificate',
             'common-name': common_name
@@ -439,12 +467,15 @@ class Template(Model):
         else:
             return None
 
-    def get_certificates_for_template(self, connection):
+    def get_certificates_for_template(self, connection=None):
         """
         Get a list of the certificates for this template.
 
         :return: The certificate list.
         """
+        if connection == None:
+            connection = self.connection
+
         struct = {
             'operation': 'get-certificates-for-template',
             }
@@ -459,22 +490,24 @@ class Template(Model):
         else:
             return None
 
-    def get_pending_certificate_request(self, connection,
-                                        common_name, dns_name=None, ip_addr=None):
+    def get_pending_certificate_request(self, common_name,
+                                        dns_name=None, ip_addr=None,
+                                        connection=None):
         pass
 
-    def insert_host_certificates(self, connection, certs, pkeys):
+    def insert_host_certificates(self, certs, pkeys, connection=None):
         pass
 
-    def need_certificate(self, connection,
-                         common_name, dns_name=None, ip_addr=None):
+    def need_certificate(self, common_name, dns_name=None, ip_addr=None,
+                         connection=None):
         pass
 
-    def generate_certificate_request(self, connection,
-                                     common_name, dns_name=None, ip_addr=None):
+    def generate_certificate_request(self,
+                                     common_name, dns_name=None, ip_addr=None,
+                                     connection=None):
         pass
 
-    def get_template_certificate_authority(self, connection):
+    def get_template_certificate_authority(self, connection=None):
         pass
 
     # ============================================================

--- a/marklogic/models/privilege.py
+++ b/marklogic/models/privilege.py
@@ -171,7 +171,7 @@ class Privilege(Model,PropertyLists):
         result.the_kind = kind
         return result
 
-    def create(self, connection):
+    def create(self, connection=None):
         """
         Creates the Privilege on the MarkLogic server.
 
@@ -208,7 +208,7 @@ class Privilege(Model,PropertyLists):
             self.etag = priv.etag
             return self
 
-    def update(self, connection):
+    def update(self, connection=None):
         """
         Updates the Privilege on the MarkLogic server.
 
@@ -229,7 +229,7 @@ class Privilege(Model,PropertyLists):
 
         return self
 
-    def delete(self, connection):
+    def delete(self, connection=None):
         """
         Deletes the Privilege from the MarkLogic server.
 

--- a/marklogic/models/role.py
+++ b/marklogic/models/role.py
@@ -293,13 +293,16 @@ class Role(Model,PropertyLists):
             self.etag = role.etag
             return self
 
-    def update(self, connection):
+    def update(self, connection=None):
         """
         Updates the Role on the MarkLogic server.
 
         :param connection: The connection to a MarkLogic server
         :return: The Role object
         """
+        if connection is None:
+            connection = self.connection
+
         uri = connection.uri("roles", self.name)
         response = connection.put(uri, payload=self._config, etag=self.etag)
 
@@ -309,13 +312,15 @@ class Role(Model,PropertyLists):
 
         return self
 
-    def delete(self, connection):
+    def delete(self, connection=None):
         """
         Deletes the Role from the MarkLogic server.
 
         :param connection: The connection to a MarkLogic server
         :return: The Role object
         """
+        if connection is None:
+            connection = self.connection
         uri = connection.uri("roles", self.name, properties=None)
         response = connection.delete(uri)
         return self

--- a/marklogic/models/user.py
+++ b/marklogic/models/user.py
@@ -252,7 +252,7 @@ class User(Model,PropertyLists):
         response = connection.post(uri, payload=self._config)
         return self
 
-    def read(self, connection):
+    def read(self, connection=None):
         """
         Loads the User from the MarkLogic server. This will refresh
         the properties of the object.
@@ -260,6 +260,9 @@ class User(Model,PropertyLists):
         :param connection: The connection to a MarkLogic server
         :return: The User object
         """
+        if connection is None:
+            connection = self.connection
+
         user = User.lookup(connection, self._config['user-name'])
         if user is None:
             return None
@@ -268,7 +271,7 @@ class User(Model,PropertyLists):
             self.etag = user.etag
             return self
 
-    def update(self, connection):
+    def update(self, connection=None):
         """
         Updates the User on the MarkLogic server.
 
@@ -287,7 +290,7 @@ class User(Model,PropertyLists):
 
         return self
 
-    def delete(self, connection):
+    def delete(self, connection=None):
         """
         Deletes the User from the MarkLogic server.
 


### PR DESCRIPTION
A while back, I adopted the convention that it would be possible to pass the connection on object creation and that would be cached. This patch fixes a few outstanding places where that hadn't been implemented.
