### PR TITLE
Improve CLI handling of properties

### DIFF
--- a/marklogic/__init__.py
+++ b/marklogic/__init__.py
@@ -35,7 +35,7 @@ from marklogic.models.server import Server, HttpServer, WebDAVServer
 from marklogic.models.server import OdbcServer, XdbcServer, WebDAVServer
 from marklogic.exceptions import *
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 class MarkLogic:
     """

--- a/marklogic/cli/manager/forest.py
+++ b/marklogic/cli/manager/forest.py
@@ -38,20 +38,23 @@ class ForestManager(Manager):
         pass
 
     def list(self, args, config, connection):
-        print(Forest.list(connection))
+        forests = Forest.list(connection)
+        print(json.dumps(forests, sort_keys=True, indent=2))
 
     def create(self, args, config, connection):
-        forest = Forest(args['name'], args['forest_host'], connection=connection)
-        if forest.exists():
-            self.logger.error("Forest already exists: {0}".format(args['name']))
-            sys.exit(1)
+        name = args['name']
+        host = args['forest_host']
 
         if args['json'] is not None:
-            newforest = self._read(args['name'], args['json'])
-            newforest.connection = forest.connection
-            if newforest.host() is None:
-                newforest.set_host(args['forest_host'])
-            forest = newforest
+            forest = self._read(name, args['json'], connection=connection)
+            name = forest.forest_name()
+            host = forest.host()
+        else:
+            forest = Forest(name, host, connection=connection)
+
+        if forest.exists():
+            self.logger.error("Forest already exists: {0}".format(name))
+            sys.exit(1)
 
         self._properties(forest, args)
         dbname = forest.database()
@@ -62,7 +65,7 @@ class ForestManager(Manager):
         else:
             database = None
 
-        self.logger.info("Create forest {0}...".format(args['name']))
+        self.logger.info("Create forest {0}...".format(name))
         forest.create(connection=connection)
 
         if database is not None:
@@ -106,9 +109,19 @@ class ForestManager(Manager):
         forest.read()
         self.jprint(forest)
 
-    def _read(self, name, jsonfile):
+    def _read(self, name, jsonfile,
+              connection=None, save_connection=True):
         jf = open(jsonfile).read()
         data = json.loads(jf)
-        data['forest-name'] = name
-        forest = Forest.unmarshal(data)
+
+        if name is not None:
+            data['forest-name'] = name
+
+        if 'database' in data:
+            del(data['database'])
+
+        forest = Forest.unmarshal(data,
+                                  connection=connection,
+                                  save_connection=save_connection)
+
         return forest

--- a/marklogic/cli/template.py
+++ b/marklogic/cli/template.py
@@ -183,7 +183,7 @@ class Template:
         self._parsers['run']['parser'] = parser
 
         parser = self._make_parser('create','forest','Create a forest')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The forest name')
         parser.add_argument('--forest-host', default='$ML-LOCALHOST',
                             help='The host on which to create the forest')
@@ -191,13 +191,11 @@ class Template:
                             help='The properties')
         parser.add_argument('properties', nargs="*",
                             metavar="property=value",
-
-
                             help='Additional forest properties')
         self._parsers['create']['forest']['parser'] = parser
 
         parser = self._make_parser('create','database','Create a database')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The database name')
         parser.add_argument('--forest-host', default='$ML-LOCALHOST',
                             help='The host on which to create forests')
@@ -209,7 +207,7 @@ class Template:
         self._parsers['create']['database']['parser'] = parser
 
         parser = self._make_parser('create','group','Create a group')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The group name')
         parser.add_argument('--json',
                             help='The properties')
@@ -218,19 +216,20 @@ class Template:
                             help='Additional database properties')
         self._parsers['create']['group']['parser'] = parser
 
-        parser = self._make_parser('create','server','Create an application server')
-        parser.add_argument('name',
+        parser = self._make_parser('create','server',
+                                   'Create an application server2')
+        parser.add_argument('name', nargs='?', default=None,
                             help='The server name')
         parser.add_argument('--type', choices=['http','odbc','xdbc','webdav'],
                             default='http',
                             help='The type of server')
         parser.add_argument('--group', default="Default",
                             help='The group')
-        parser.add_argument('--port', type=int, required=True,
+        parser.add_argument('--port', type=int, default=0,
                             help='The port number')
-        parser.add_argument('--root', required=True,
+        parser.add_argument('--root', default=None,
                             help='The root path')
-        parser.add_argument('--database', required=True,
+        parser.add_argument('--database', default=None,
                             help='The content database')
         parser.add_argument('--modules', default=None,
                             help='The modules database')
@@ -242,9 +241,9 @@ class Template:
         self._parsers['create']['server']['parser'] = parser
 
         parser = self._make_parser('create','user','Create a user')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The user name')
-        parser.add_argument('--password', required=True,
+        parser.add_argument('--password', default=None,
                             help='The user password')
         parser.add_argument('--json',
                             help='The properties')
@@ -254,7 +253,7 @@ class Template:
         self._parsers['create']['user']['parser'] = parser
 
         parser = self._make_parser('create','role','Create a role')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The role name')
         parser.add_argument('--json',
                             help='The properties')
@@ -264,11 +263,12 @@ class Template:
         self._parsers['create']['role']['parser'] = parser
 
         parser = self._make_parser('create','privilege','Create a privilege')
-        parser.add_argument('name',
+        parser.add_argument('name', nargs='?', default=None,
                             help='The privilege name')
-        parser.add_argument('--kind', choices=['execute','uri'], required=True,
+        parser.add_argument('--kind', choices=['execute','uri'],
+                            default=None,
                             help='The privilege kind')
-        parser.add_argument('--action', required=True,
+        parser.add_argument('--action', default=None,
                             help='The URI to protect')
         parser.add_argument('--json',
                             help='The properties')

--- a/marklogic/models/database/__init__.py
+++ b/marklogic/models/database/__init__.py
@@ -3267,8 +3267,10 @@ class Database(Model,PropertyLists):
         return result
 
     @classmethod
-    def unmarshal(cls, config):
-        result = Database("temp")
+    def unmarshal(cls, config, hostname=None,
+                  connection=None, save_connection=True):
+        result = Database("temp", hostname,
+                          connection=connection, save_connection=save_connection)
         result._config = config
         result.name = result._config['database-name']
 

--- a/marklogic/models/forest/__init__.py
+++ b/marklogic/models/forest/__init__.py
@@ -364,8 +364,9 @@ class Forest(Model,PropertyLists):
         return result
 
     @classmethod
-    def unmarshal(cls, config):
-        result = Forest("temp")
+    def unmarshal(cls, config, connection=None, save_connection=True):
+        result = Forest("temp",
+                        connection=connection, save_connection=save_connection)
         result._config = config
         result.name = result._config['forest-name']
 

--- a/marklogic/models/forest/__init__.py
+++ b/marklogic/models/forest/__init__.py
@@ -376,7 +376,8 @@ class Forest(Model,PropertyLists):
                   'database-replication', 'enabled',
                   'failover-enable', 'fast-data-directory',
                   'forest-name', 'host', 'large-data-directory',
-                  'range', 'rebalancer-enable', 'updates-allowed'
+                  'range', 'rebalancer-enable', 'updates-allowed',
+                  'database'
                   }
 
         for key in result._config:

--- a/marklogic/models/group/__init__.py
+++ b/marklogic/models/group/__init__.py
@@ -99,7 +99,8 @@ class Group(Model,PropertyLists):
         return struct
 
     @classmethod
-    def unmarshal(cls, config):
+    def unmarshal(cls, config,
+                  connection=None, save_connection=True):
         """
         Construct a new group from a flat structure. This method is
         principally used to construct an object from a Management API
@@ -109,7 +110,8 @@ class Group(Model,PropertyLists):
         :param: config: A hash of properties
         :return: A newly constructed Group object with the specified properties.
         """
-        result = Group("temp")
+        result = Group("temp", connection=connection,
+                       save_connection=save_connection)
         result._config = config
         result.name = config['group-name']
         result.etag = None
@@ -222,7 +224,7 @@ class Group(Model,PropertyLists):
             connection = self.connection
 
         uri = connection.uri("groups")
-        struct = self.marshall()
+        struct = self.marshal()
         response = connection.post(uri, payload=struct)
         return self
 

--- a/marklogic/models/privilege.py
+++ b/marklogic/models/privilege.py
@@ -152,7 +152,7 @@ class Privilege(Model,PropertyLists):
         return struct
 
     @classmethod
-    def unmarshal(cls, config):
+    def unmarshal(cls, config, connection=None, save_connection=True):
         """
         Construct a new Privilege from a flat structure. This method is
         principally used to construct an object from a Management API
@@ -165,7 +165,10 @@ class Privilege(Model,PropertyLists):
         kind = config['kind']
         validate_privilege_kind(kind)
 
-        result = Privilege("temp", kind, "http://example.com/")
+        result = Privilege("temp", kind, "http://example.com/",
+                           connection=connection,
+                           save_connection=save_connection)
+
         result._config = config
         result.name = config['privilege-name']
         result.the_kind = kind

--- a/marklogic/models/role.py
+++ b/marklogic/models/role.py
@@ -233,13 +233,13 @@ class Role(Model,PropertyLists):
         return self._get_config_property('privilege')
 
     @classmethod
-    def unmarshal(cls, config):
+    def unmarshal(cls, config, connection=None, save_connection=True):
         """
         Return a flat structure suitable for conversion to JSON or XML.
 
         :return: A hash of the keys in this object and their values, recursively.
         """
-        result = Role("temp")
+        result = Role("temp", connection, save_connection)
         result._config = config
         result.name = config['role-name']
         result.etag = None

--- a/marklogic/models/server/__init__.py
+++ b/marklogic/models/server/__init__.py
@@ -1476,7 +1476,7 @@ class Server(Model,PropertyLists):
             return None
 
     @classmethod
-    def unmarshal(cls, config):
+    def unmarshal(cls, config, connection=None, save_connection=True):
         """
         Construct a new server from a flat structure. This method is
         principally used to construct an object from a Management API
@@ -1491,13 +1491,21 @@ class Server(Model,PropertyLists):
 
         result = None
         if config['server-type'] == 'http':
-            result = HttpServer(name, group)
+            result = HttpServer(name, group,
+                                connection=connection,
+                                save_connection=save_connection)
         if config['server-type'] == 'odbc':
-            result = OdbcServer(name, group)
+            result = OdbcServer(name, group,
+                                connection=connection,
+                                save_connection=save_connection)
         if config['server-type'] == 'xdbc':
-            result = XdbcServer(name, group)
+            result = XdbcServer(name, group,
+                                connection=connection,
+                                save_connection=save_connection)
         if config['server-type'] == 'webdav':
-            result = WebDAVServer(name, group)
+            result = WebDAVServer(name, group,
+                                connection=connection,
+                                save_connection=save_connection)
 
         if result is None:
             raise UnexpectedManagementAPIResponse("Unexpected server type")

--- a/marklogic/models/user.py
+++ b/marklogic/models/user.py
@@ -209,7 +209,7 @@ class User(Model,PropertyLists):
         return struct
 
     @classmethod
-    def unmarshal(cls, config):
+    def unmarshal(cls, config, connection=None, save_connection=True):
         """
         Construct a new User from a flat structure. This method is
         principally used to construct an object from a Management API
@@ -219,7 +219,8 @@ class User(Model,PropertyLists):
         :param: config: A hash of properties
         :return: A newly constructed User object with the specified properties.
         """
-        result = User("temp")
+        result = User("temp",
+                      connection=connection, save_connection=save_connection)
         result._config = config
         result.name = config['user-name']
         result.etag = None


### PR DESCRIPTION
* The CLI had previously required some arguments even if they were in the JSON payload provided. Those arguments are now all optional and will be read from the payload. For example:

````
$ mma.py create user --json user.json
````

It's still an error, obviously, if the required fields are neither provided on the command line nor present in the payload. Arguments provided on the command line trump arguments provided in the payload.

* Instead of requiring a password for new users, If no password is provided for a user, a long, cryptographically random password will be generated.

* Added a workaround for forest properties that are not (yet) supported by (some) releases of the server.
