### PR TITLE
Add "verify" to the Connection class & pass to the Requests class

### DIFF
--- a/marklogic/connection.py
+++ b/marklogic/connection.py
@@ -99,7 +99,7 @@ class Connection:
 
     def head(self, uri, accept="application/json"):
         self.logger.debug("HEAD {0}...".format(uri))
-        self.response = requests.head(uri, auth=self.auth, verify=verify)
+        self.response = requests.head(uri, auth=self.auth, verify=self.verify)
         return self._response()
 
     def get(self, uri, accept="application/json", headers=None):
@@ -112,7 +112,7 @@ class Connection:
         self.payload_logger.debug("Headers:")
         self.payload_logger.debug(json.dumps(headers, indent=2))
 
-        self.response = requests.get(uri, auth=self.auth, headers=headers, verify=verify)
+        self.response = requests.get(uri, auth=self.auth, headers=headers, verify=self.verify)
         return self._response()
 
     def post(self, uri, payload=None, etag=None,
@@ -134,14 +134,14 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.post(uri, auth=self.auth, headers=headers, verify=verify)
+            self.response = requests.post(uri, auth=self.auth, headers=headers, verify=self.verify)
         else:
             if content_type == "application/json":
                 self.response = requests.post(uri, json=payload,
-                                              auth=self.auth, headers=headers, verify=verify)
+                                              auth=self.auth, headers=headers, verify=self.verify)
             else:
                 self.response = requests.post(uri, data=payload,
-                                              auth=self.auth, headers=headers, verify=verify)
+                                              auth=self.auth, headers=headers, verify=self.verify)
 
         return self._response()
 
@@ -164,14 +164,14 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.put(uri, auth=self.auth, headers=headers, verify=verify)
+            self.response = requests.put(uri, auth=self.auth, headers=headers, verify=self.verify)
         else:
             if content_type == "application/json":
                 self.response = requests.put(uri, json=payload,
-                                                 auth=self.auth, headers=headers, verify=verify)
+                                                 auth=self.auth, headers=headers, verify=self.verify)
             else:
                 self.response = requests.put(uri, data=payload,
-                                                 auth=self.auth, headers=headers, verify=verify)
+                                                 auth=self.auth, headers=headers, verify=self.verify)
 
         return self._response()
 
@@ -194,10 +194,10 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.delete(uri, auth=self.auth, headers=headers, verify=verify)
+            self.response = requests.delete(uri, auth=self.auth, headers=headers, verify=self.verify)
         else:
             self.response = requests.delete(uri, json=payload,
-                                            auth=self.auth, headers=headers, verify=verify)
+                                            auth=self.auth, headers=headers, verify=self.verify)
 
         return self._response()
 
@@ -240,7 +240,7 @@ class Connection:
             try:
                 self.logger.debug("Waiting for restart of {0}".format(self.host))
                 response = requests.get(uri, auth=self.auth,
-                                             headers={'accept': 'application/json'}, verify=verify)
+                                             headers={'accept': 'application/json'}, verify=self.verify)
                 done = response.status_code == 200 and response.text != last_startup
             except TypeError:
                 self.logger.debug("{0}: {1}".format(response.status_code,

--- a/marklogic/connection.py
+++ b/marklogic/connection.py
@@ -38,7 +38,7 @@ class Connection:
     """
     def __init__(self, host, auth,
                  protocol="http", port=8000, management_port=8002,
-                 root="manage", version="v2", client_version="v1"):
+                 root="manage", version="v2", client_version="v1", verify=False):
         self.host = host
         self.auth = auth
         self.protocol = protocol
@@ -47,6 +47,7 @@ class Connection:
         self.root = root
         self.version = version
         self.client_version = client_version
+        self.verify = verify
         self.logger = logging.getLogger("marklogic.connection")
         self.payload_logger = logging.getLogger("marklogic.connection.payloads")
 
@@ -98,7 +99,7 @@ class Connection:
 
     def head(self, uri, accept="application/json"):
         self.logger.debug("HEAD {0}...".format(uri))
-        self.response = requests.head(uri, auth=self.auth)
+        self.response = requests.head(uri, auth=self.auth, verify=verify)
         return self._response()
 
     def get(self, uri, accept="application/json", headers=None):
@@ -111,7 +112,7 @@ class Connection:
         self.payload_logger.debug("Headers:")
         self.payload_logger.debug(json.dumps(headers, indent=2))
 
-        self.response = requests.get(uri, auth=self.auth, headers=headers)
+        self.response = requests.get(uri, auth=self.auth, headers=headers, verify=verify)
         return self._response()
 
     def post(self, uri, payload=None, etag=None,
@@ -133,14 +134,14 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.post(uri, auth=self.auth, headers=headers)
+            self.response = requests.post(uri, auth=self.auth, headers=headers, verify=verify)
         else:
             if content_type == "application/json":
                 self.response = requests.post(uri, json=payload,
-                                              auth=self.auth, headers=headers)
+                                              auth=self.auth, headers=headers, verify=verify)
             else:
                 self.response = requests.post(uri, data=payload,
-                                              auth=self.auth, headers=headers)
+                                              auth=self.auth, headers=headers, verify=verify)
 
         return self._response()
 
@@ -163,14 +164,14 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.put(uri, auth=self.auth, headers=headers)
+            self.response = requests.put(uri, auth=self.auth, headers=headers, verify=verify)
         else:
             if content_type == "application/json":
                 self.response = requests.put(uri, json=payload,
-                                                 auth=self.auth, headers=headers)
+                                                 auth=self.auth, headers=headers, verify=verify)
             else:
                 self.response = requests.put(uri, data=payload,
-                                                 auth=self.auth, headers=headers)
+                                                 auth=self.auth, headers=headers, verify=verify)
 
         return self._response()
 
@@ -193,10 +194,10 @@ class Connection:
                 self.payload_logger.debug(payload)
 
         if payload is None:
-            self.response = requests.delete(uri, auth=self.auth, headers=headers)
+            self.response = requests.delete(uri, auth=self.auth, headers=headers, verify=verify)
         else:
             self.response = requests.delete(uri, json=payload,
-                                            auth=self.auth, headers=headers)
+                                            auth=self.auth, headers=headers, verify=verify)
 
         return self._response()
 
@@ -239,7 +240,7 @@ class Connection:
             try:
                 self.logger.debug("Waiting for restart of {0}".format(self.host))
                 response = requests.get(uri, auth=self.auth,
-                                             headers={'accept': 'application/json'})
+                                             headers={'accept': 'application/json'}, verify=verify)
                 done = response.status_code == 200 and response.text != last_startup
             except TypeError:
                 self.logger.debug("{0}: {1}".format(response.status_code,

--- a/test/ssl/resources.py
+++ b/test/ssl/resources.py
@@ -1,0 +1,5 @@
+class TestConnection(object):
+    hostname = "192.168.200.162"
+    admin = "admin"
+    password = "admin"
+    sslport = 8003

--- a/test/ssl/test_ssl_connection.py
+++ b/test/ssl/test_ssl_connection.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function, absolute_import
+
+#
+# Copyright 2016 MarkLogic Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0#
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# File History
+# ------------
+#
+# Philip Barber      02/14/2016     Initial development
+#
+
+import unittest
+from requests.auth import HTTPDigestAuth
+from marklogic.models import Database, Server, Forest
+from marklogic.connection import Connection
+from test.ssl.resources import TestConnection as tc
+
+class TestSslConnection(unittest.TestCase):
+    """
+    Basic creation test function.
+    """
+    def test_check_ssl_manage_server(self):
+        conn = Connection(tc.hostname,
+             HTTPDigestAuth(tc.admin, tc.password),
+             protocol="https",
+             verify = "",
+             management_port=tc.sslport)
+        server = Server.lookup(conn, "Default|Manage")
+        self.assertIsNotNone(server)
+        self.assertEqual('Manage', server.server_name())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I created a test for this extension. Since the test requires an SSL-enabled app server, I created the test in a separate directory with it's own resources file. It's a VERY simple test, but all it needs to do is show that the Connection class can communicate with an SSL-enabled app server.