### PR TITLE
A couple of small client fixes

### DIFF
--- a/marklogic/client/documents.py
+++ b/marklogic/client/documents.py
@@ -497,7 +497,7 @@ class Documents(PropertyLists):
             xml += "<rapi:collections>\n"
             for collection in self._config['collection']:
                 xml += "<rapi:collection>{}</rapi:collection>\n".format(collection)
-            xml += "</rapi:collections\n"
+            xml += "</rapi:collections>\n"
 
         if self.permissions:
             xml += "<rapi:permissions>\n"


### PR DESCRIPTION
1. Fix a bug in the payload for properties in documents
2. Support time limits on transactions
3. Added a method to work out the maximum allowed time limit; it's not terribly clever
