### PR TITLE
Delete contents of data dir, not data dir

### DIFF
--- a/marklogic/cli/manager/marklogic.py
+++ b/marklogic/cli/manager/marklogic.py
@@ -71,9 +71,16 @@ class MarkLogicManager(Manager):
             if connection.host == 'localhost':
                 try:
                     data = config[args['config']]['datadir']
+                    if not os.path.isdir(data):
+                        print("Not a directory: {}".format(data))
+                        sys.exit(1)
                     print("Clearing {0}...".format(data))
-                    shutil.rmtree(data)
-                    os.mkdir(data)
+                    for name in os.listdir(data):
+                        path = os.path.join(data, name)
+                        if os.path.isdir(path):
+                            shutil.rmtree(path)
+                        else:
+                            os.remove(path)
                 except KeyError:
                     pass
             else:


### PR DESCRIPTION
The 'init' command clears the data directory (under some, possibly dubious circumstances; that's a bug for another day). It used to attempt to do that by recursively deleting the data directory and then recreating it. But if you're using, for example, /var/opt/MarkLogic as the data directory, you might have write access to that directory but not /var/opt.

So this code patches the init command to delete the contents of the data directory, not the data directory itself.
